### PR TITLE
Update p2000.py

### DIFF
--- a/p2000_rtlsdr/p2000.py
+++ b/p2000_rtlsdr/p2000.py
@@ -1006,7 +1006,7 @@ class Main:
                 else:
                     # TODO
                     # After midnight (UTC), reset the opencage disable
-                    hour = datetime.utcnow()
+                    hour = datetime.now(datetime.UTC)
                     if (
                         hour.hour >= 0
                         and hour.minute >= 1


### PR DESCRIPTION
Will this fix the error deprecation warning?

/p2000.py:1009: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  hour = datetime.utcnow()