### PR TITLE
Fix DeprecationWarning utcnow()

### DIFF
--- a/p2000_rtlsdr/p2000.py
+++ b/p2000_rtlsdr/p2000.py
@@ -9,7 +9,7 @@ import ssl
 import calendar
 import fnmatch
 import threading
-from datetime import datetime
+from datetime import timezone, datetime
 from json.decoder import JSONDecodeError
 import time
 from fcntl import ioctl
@@ -1006,7 +1006,7 @@ class Main:
                 else:
                     # TODO
                     # After midnight (UTC), reset the opencage disable
-                    hour = datetime.utcnow()
+                    hour = datetime.now(timezone.utc).replace(tzinfo=None)
                     if (
                         hour.hour >= 0
                         and hour.minute >= 1


### PR DESCRIPTION
Will fix the deprecation warning.

Source: https://github.com/dbt-labs/dbt-core/issues/9791#issuecomment-2015447724

Fixes #14 